### PR TITLE
Few improvements

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+New for release 0.9 (2019-2-12)
+  o Changed some int types to int64 (https://github.com/mnmnm/gzrt) #not sure what this improves. 
+  o Fix incorrectly decompression of a non-corrupted gzip. It does not spits binary stuff anymore for no reason. (Giovanni)
+  o Improved recovery of corrupted gziped archives (Giovanni)
+  o Do not skip gzip header, assume that it is ok. (Giovanni)
+  
 New for release 0.8 (2013-10-03)
   o Eliminate call to fsync(), resulting in 99% speed improvement
   o Add ability to read from the standard input stream and write to


### PR DESCRIPTION
Assume header exists. 
Decompress a nice gzip without skipping bytes. A non-corrupted gzipped file is decompressed in a file identical to a file decompressed by zcat. 
Improved decompression of gzip format. 